### PR TITLE
Add standalone leaderboard endpoint

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,7 @@ import { authRoutes } from '@/routes/auth'
 import { quizRoutes } from '@/routes/quiz'
 import { adminRoutes } from '@/routes/admin'
 import { websocketRoutes } from '@/routes/websocket'
+import { leaderboardRoutes } from '@/routes/leaderboard'
 import { SecureToolHandler } from '@/services/SecureToolHandler'
 import { participants } from '@/db/schema'
 import { eq } from 'drizzle-orm'
@@ -84,6 +85,7 @@ app.get('/health', (c) => {
 app.route('/api/auth', authRoutes)
 app.route('/api/quiz', quizRoutes)
 app.route('/api/admin', adminRoutes)
+app.route('/api', leaderboardRoutes)
 
 // WebSocket route (at root level)
 app.route('/', websocketRoutes)

--- a/src/routes/leaderboard.ts
+++ b/src/routes/leaderboard.ts
@@ -1,0 +1,88 @@
+import { Hono } from 'hono'
+
+// Services
+import { ScoringService } from '@/services/ScoringService'
+
+// Middleware
+import { ValidationMiddleware, querySchemas } from '@/middleware/validation'
+
+// Types
+import type { AppContext } from '@/types/api'
+import { AppError, ErrorCode } from '@/types/errors'
+
+// Utils
+import { createLogger } from '@/config/environment'
+
+const logger = createLogger('leaderboard-routes')
+
+const router = new Hono<{ Variables: any }>()
+
+router.get(
+  '/leaderboard',
+  ValidationMiddleware.validateQuery(querySchemas.leaderboard),
+  async (c: AppContext) => {
+    try {
+      const db = c.get('db')
+      const validatedQuery = c.get('validatedQuery') as {
+        limit: number
+        offset: number
+        period: 'all' | 'today' | 'week' | 'month'
+      }
+
+      const scoringService = new ScoringService(db)
+      const fullLeaderboard = await scoringService.getLeaderboard(
+        validatedQuery.limit + validatedQuery.offset
+      )
+
+      const paginatedResults = fullLeaderboard.slice(
+        validatedQuery.offset,
+        validatedQuery.offset + validatedQuery.limit
+      )
+
+      return c.json({
+        success: true,
+        data: {
+          entries: paginatedResults,
+          pagination: {
+            total: fullLeaderboard.length,
+            limit: validatedQuery.limit,
+            offset: validatedQuery.offset,
+            hasMore:
+              validatedQuery.offset + validatedQuery.limit < fullLeaderboard.length
+          }
+        },
+        timestamp: new Date().toISOString()
+      })
+    } catch (error) {
+      logger.error('Leaderboard fetch failed:', error)
+
+      if (error instanceof AppError) {
+        return c.json(
+          {
+            success: false,
+            error: {
+              code: error.code,
+              message: error.message
+            },
+            timestamp: new Date().toISOString()
+          },
+          error.statusCode as any
+        )
+      }
+
+      return c.json(
+        {
+          success: false,
+          error: {
+            code: ErrorCode.INTERNAL_SERVER_ERROR,
+            message: 'Leaderboard fetch failed'
+          },
+          timestamp: new Date().toISOString()
+        },
+        500
+      )
+    }
+  }
+)
+
+export { router as leaderboardRoutes }

--- a/src/routes/quiz.ts
+++ b/src/routes/quiz.ts
@@ -3,10 +3,9 @@ import { PromptBuilder } from '@/services/PromptBuilder'
 
 // Services
 import { SecureToolHandler } from '@/services/SecureToolHandler'
-import { ScoringService } from '@/services/ScoringService'
 
 // Middleware
-import { ValidationMiddleware, schemas, querySchemas } from '@/middleware/validation'
+import { ValidationMiddleware, schemas } from '@/middleware/validation'
 import { AuthMiddleware, getAuthenticatedUser } from '@/middleware/auth'
 
 // Types
@@ -75,66 +74,6 @@ router.post(
     }
   }
 )
-
-// Leaderboard endpoint
-router.get(
-  '/leaderboard',
-  ValidationMiddleware.validateQuery(querySchemas.leaderboard),
-  async (c: AppContext) => {
-    try {
-      const db = c.get('db')
-      const validatedQuery = c.get('validatedQuery') as {
-        limit: number
-        offset: number
-        period: 'all' | 'today' | 'week' | 'month'
-      }
-
-      const scoringService = new ScoringService(db)
-      const fullLeaderboard = await scoringService.getLeaderboard(validatedQuery.limit + validatedQuery.offset)
-      
-      // Apply pagination
-      const paginatedResults = fullLeaderboard.slice(validatedQuery.offset, validatedQuery.offset + validatedQuery.limit)
-
-      return c.json({
-        success: true,
-        data: {
-          entries: paginatedResults,
-          pagination: {
-            total: fullLeaderboard.length,
-            limit: validatedQuery.limit,
-            offset: validatedQuery.offset,
-            hasMore: validatedQuery.offset + validatedQuery.limit < fullLeaderboard.length
-          }
-        },
-        timestamp: new Date().toISOString()
-      })
-
-    } catch (error) {
-      logger.error('Leaderboard fetch failed:', error)
-      
-      if (error instanceof AppError) {
-        return c.json({
-          success: false,
-          error: {
-            code: error.code,
-            message: error.message
-          },
-          timestamp: new Date().toISOString()
-        }, error.statusCode as any)
-      }
-
-      return c.json({
-        success: false,
-        error: {
-          code: ErrorCode.INTERNAL_SERVER_ERROR,
-          message: 'Leaderboard fetch failed'
-        },
-        timestamp: new Date().toISOString()
-      }, 500)
-    }
-  }
-)
-
 // Export router
 // Ephemeral token endpoint for OpenAI Realtime API
 router.post('/realtime/ephemeral-token', async (c: AppContext) => {


### PR DESCRIPTION
## Summary
- Create dedicated leaderboard router and mount at `/api/leaderboard`
- Remove leaderboard code from quiz router to avoid 404

## Testing
- `bun test`
- `bun run type-check` *(fails: Cannot find module 'jose')*


------
https://chatgpt.com/codex/tasks/task_b_68c5e27ce98c832eb89a0042aae7a768