### PR TITLE
Prevent duplicate timing events

### DIFF
--- a/tests/unit/TimingService.test.ts
+++ b/tests/unit/TimingService.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'bun:test';
+
+process.env.NODE_ENV = 'development';
+process.env.OPENAI_API_KEY = 'test';
+process.env.JWT_SECRET = '12345678901234567890123456789012';
+process.env.ADMIN_PASSWORD_HASH = 'test';
+
+const { TimingService } = await import('@/services/TimingService');
+
+class FakeDB {
+  public inserted: any[] = [];
+  insert(_table: any) {
+    return {
+      values: async (data: any) => {
+        this.inserted.push(data);
+      },
+    };
+  }
+}
+
+describe('TimingService duplicate event prevention', () => {
+  it('records only the first occurrence of an identical event', async () => {
+    const db = new FakeDB();
+    const service = new TimingService(db as any);
+    const event = { sessionQuestionId: 'sq1', eventType: 'tts_start' as const };
+
+    const firstId = await service.markTimingEvent(event);
+    const secondId = await service.markTimingEvent(event);
+
+    expect(secondId).toBe(firstId);
+    expect(db.inserted.length).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary
- avoid duplicate timing events within a short period
- test timing service to ensure duplicates are ignored

## Testing
- `bun test`
- `bun run lint` *(fails: ESLint errors across repository)*

------
https://chatgpt.com/codex/tasks/task_b_68c5e5a769bc832e81880b653e9d7bd1